### PR TITLE
Reaction to Rmagine Update + Cleanup

### DIFF
--- a/rmcl/CMakeLists.txt
+++ b/rmcl/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(rmcl
     LANGUAGES CXX C
-	VERSION 2.2.2
+	VERSION 2.2.3
 	)
 
 option(BUILD_TESTS "Build tests" ON)

--- a/rmcl/CMakeLists.txt
+++ b/rmcl/CMakeLists.txt
@@ -54,7 +54,7 @@ list(APPEND CMAKE_MODULE_PATH ${rmcl_SOURCE_DIR}/cmake)
 # only print warning for Rmagine version greater than RMAGINE_MAX_VERSION
 set(RMAGINE_MAX_VERSION "2.4.0")
 
-find_package(rmagine 2.3.0
+find_package(rmagine 2.3.1
     COMPONENTS
         core
     OPTIONAL_COMPONENTS
@@ -147,12 +147,6 @@ set_target_properties(rmcl
       VERSION ${rmcl_VERSION}
       # CXX_STANDARD 17
 )
-
-# install(TARGETS rmcl
-#     EXPORT rmcl-targets
-#     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-#     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-# )
 
 # EMBREE
 if(TARGET rmagine::embree)

--- a/rmcl/package.xml
+++ b/rmcl/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
     <name>rmcl</name>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
     <description>The rmcl package</description>
 
     <maintainer email="amock@uos.de">Alexander Mock</maintainer>

--- a/rmcl_msgs/CMakeLists.txt
+++ b/rmcl_msgs/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(rmcl_msgs VERSION 2.2.2)
+project(rmcl_msgs VERSION 2.2.3)
 
 # Default to C++17
 if(NOT CMAKE_CXX_STANDARD)

--- a/rmcl_msgs/package.xml
+++ b/rmcl_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmcl_msgs</name>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <description>The rmcl_msgs package</description>
   <maintainer email="amock@uos.de">Alexander Mock</maintainer>
   <author email="amock@uos.de">Alexander Mock</author>

--- a/rmcl_ros/CMakeLists.txt
+++ b/rmcl_ros/CMakeLists.txt
@@ -29,39 +29,6 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
-
-
-
-
-
-
-# function(print_link_info tgt)
-#   message(STATUS "--- ${tgt} ---")
-#   foreach(prop
-#     LINK_DIRECTORIES
-#     INTERFACE_LINK_DIRECTORIES
-#     LINK_LIBRARIES
-#     INTERFACE_LINK_LIBRARIES
-#     IMPORTED_LINK_INTERFACE_LIBRARIES
-#     )
-#     get_property(val TARGET ${tgt} PROPERTY ${prop})
-#     if(val)
-#       message(STATUS "- ${prop} = ${val}")
-#     endif()
-#   endforeach()
-
-#   # Per-config (useful for imported targets)
-#   foreach(cfg Debug Release RelWithDebInfo MinSizeRel)
-#     get_property(percfg TARGET ${tgt} PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_${cfg})
-#     if(percfg)
-#       message(STATUS "${tgt} :: IMPORTED_LINK_INTERFACE_LIBRARIES_${cfg} = ${percfg}")
-#     endif()
-#   endforeach()
-# endfunction()
-
-
-
-
 find_package(ament_cmake REQUIRED)
 
 find_package(rclcpp REQUIRED)
@@ -74,7 +41,6 @@ find_package(visualization_msgs REQUIRED)
 
 find_package(OpenMP REQUIRED)
 
-
 find_package(rmagine 2.3.1
     COMPONENTS
         core
@@ -84,7 +50,7 @@ find_package(rmagine 2.3.1
         optix
 )
 
-find_package(rmcl 2.2.1 REQUIRED)
+find_package(rmcl 2.2.3 REQUIRED)
 include_directories(${rmcl_INCLUDE_DIR})
 
 # TODO: we can do this better. maybe put definitions to each target?

--- a/rmcl_ros/CMakeLists.txt
+++ b/rmcl_ros/CMakeLists.txt
@@ -29,6 +29,39 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
+
+
+
+
+
+
+# function(print_link_info tgt)
+#   message(STATUS "--- ${tgt} ---")
+#   foreach(prop
+#     LINK_DIRECTORIES
+#     INTERFACE_LINK_DIRECTORIES
+#     LINK_LIBRARIES
+#     INTERFACE_LINK_LIBRARIES
+#     IMPORTED_LINK_INTERFACE_LIBRARIES
+#     )
+#     get_property(val TARGET ${tgt} PROPERTY ${prop})
+#     if(val)
+#       message(STATUS "- ${prop} = ${val}")
+#     endif()
+#   endforeach()
+
+#   # Per-config (useful for imported targets)
+#   foreach(cfg Debug Release RelWithDebInfo MinSizeRel)
+#     get_property(percfg TARGET ${tgt} PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_${cfg})
+#     if(percfg)
+#       message(STATUS "${tgt} :: IMPORTED_LINK_INTERFACE_LIBRARIES_${cfg} = ${percfg}")
+#     endif()
+#   endforeach()
+# endfunction()
+
+
+
+
 find_package(ament_cmake REQUIRED)
 
 find_package(rclcpp REQUIRED)
@@ -42,7 +75,7 @@ find_package(visualization_msgs REQUIRED)
 find_package(OpenMP REQUIRED)
 
 
-find_package(rmagine 2.3.0
+find_package(rmagine 2.3.1
     COMPONENTS
         core
     OPTIONAL_COMPONENTS
@@ -51,14 +84,14 @@ find_package(rmagine 2.3.0
         optix
 )
 
-find_package(rmcl 2.2 REQUIRED)
+find_package(rmcl 2.2.1 REQUIRED)
 include_directories(${rmcl_INCLUDE_DIR})
 
-# TODO: we can do this better. maybe but definitions to each target?
-if(TARGET rmagine::embree)
+# TODO: we can do this better. maybe put definitions to each target?
+if(TARGET rmcl-embree)
     add_definitions(-DRMCL_EMBREE)
     set(RMCL_EMBREE TRUE)
-endif(TARGET rmagine::embree)
+endif(TARGET rmcl-embree)
 
 if(TARGET rmcl-cuda)
     add_definitions(-DRMCL_CUDA)
@@ -70,7 +103,6 @@ if(TARGET rmcl-optix)
     set(RMCL_OPTIX True)
 endif(TARGET rmcl-optix)
 
-# find_package(Eigen3 REQUIRED)
 
 include_directories(
     include
@@ -91,8 +123,8 @@ add_library(rmcl_ros SHARED
 )
 
 target_include_directories(rmcl_ros PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<INSTALL_INTERFACE:include>")
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
 
 target_link_libraries(rmcl_ros
     rmcl
@@ -114,35 +146,6 @@ install(TARGETS rmcl_ros
     RUNTIME DESTINATION bin
 )
 
-if(RMCL_EMBREE)
-    # add_library(rmcl_ros_embree SHARED
-    #     src/micpl/correspondences/RCCEmbree.cpp
-    #     src/micpl/correspondences/CPCEmbree.cpp
-    # )
-    # target_include_directories(rmcl_ros_embree PUBLIC
-    #     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    #     "$<INSTALL_INTERFACE:include>")
-    # target_link_libraries(rmcl_ros_embree
-    #     rmcl_ros
-    #     rmcl-embree
-    #     rmagine::embree
-    #     OpenMP::OpenMP_CXX
-    # )
-
-    # ament_target_dependencies(rmcl_ros_embree
-    #     rclcpp
-    #     sensor_msgs
-    #     rmcl_msgs
-    #     geometry_msgs
-    # )
-
-    # install(TARGETS rmcl_ros_embree
-    #     ARCHIVE DESTINATION lib
-    #     LIBRARY DESTINATION lib
-    #     RUNTIME DESTINATION bin
-    # )
-endif(RMCL_EMBREE)
-
 if(RMCL_CUDA)
     add_library(rmcl_ros_cuda SHARED
         src/micpl/MICPSensorCUDA.cpp
@@ -152,8 +155,9 @@ if(RMCL_CUDA)
         src/micpl/MICPOnDnSensorCUDA.cpp
     )
     target_include_directories(rmcl_ros_cuda PUBLIC
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-        "$<INSTALL_INTERFACE:include>")
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    )
     target_link_libraries(rmcl_ros_cuda
         rmcl_ros
         rmcl-cuda
@@ -173,33 +177,6 @@ if(RMCL_CUDA)
         RUNTIME DESTINATION bin
     )
 endif(RMCL_CUDA)
-
-if(RMCL_OPTIX)
-    # add_library(rmcl_ros_optix SHARED
-    #     src/micpl/correspondences/RCCOptix.cpp
-    # )
-    # target_include_directories(rmcl_ros_optix PUBLIC
-    #     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    #     "$<INSTALL_INTERFACE:include>")
-    # target_link_libraries(rmcl_ros_optix
-    #     rmcl_ros
-    #     rmcl-optix
-    #     rmagine::optix
-    # )
-
-    # ament_target_dependencies(rmcl_ros_optix
-    #     rclcpp
-    #     sensor_msgs
-    #     rmcl_msgs
-    #     geometry_msgs
-    # )
-
-    # install(TARGETS rmcl_ros_optix
-    #     ARCHIVE DESTINATION lib
-    #     LIBRARY DESTINATION lib
-    #     RUNTIME DESTINATION bin
-    # )
-endif(RMCL_OPTIX)
 
 ## Nodes
 

--- a/rmcl_ros/CMakeLists.txt
+++ b/rmcl_ros/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(rmcl_ros
-	VERSION 2.2.2)
+	VERSION 2.2.3)
 
 option(BUILD_EXPERIMENTAL "Build Experimental Code" OFF)
 option(BUILD_MICP_EXPERIMENTS "Build Experiments" OFF)

--- a/rmcl_ros/include/rmcl_ros/micpl/MICPO1DnSensorCPU.hpp
+++ b/rmcl_ros/include/rmcl_ros/micpl/MICPO1DnSensorCPU.hpp
@@ -20,18 +20,14 @@
 
 #include <message_filters/subscriber.h>
 
-
 #include <rmagine/math/statistics.h>
 #include <rmagine/math/linalg.h>
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 
-// Correspondences
-#include <rmcl/registration/Correspondences.hpp>
-#include <rmcl/registration/RCCEmbree.hpp>
-
 #include <mutex>
 #include <thread>
+
 namespace rmcl
 {
 

--- a/rmcl_ros/include/rmcl_ros/micpl/MICPO1DnSensorCUDA.hpp
+++ b/rmcl_ros/include/rmcl_ros/micpl/MICPO1DnSensorCUDA.hpp
@@ -16,7 +16,6 @@
 
 #include <message_filters/subscriber.h>
 
-
 #include <rmagine/math/statistics.h>
 #include <rmagine/types/MemoryCuda.hpp>
 

--- a/rmcl_ros/include/rmcl_ros/micpl/MICPOnDnSensorCPU.hpp
+++ b/rmcl_ros/include/rmcl_ros/micpl/MICPOnDnSensorCPU.hpp
@@ -20,21 +20,13 @@
 
 #include <message_filters/subscriber.h>
 
-
 #include <rmagine/math/statistics.h>
 #include <rmagine/math/linalg.h>
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 
-// Correspondences
-#include <rmcl/registration/Correspondences.hpp>
-#include <rmcl/registration/RCCEmbree.hpp>
-
-
 #include <mutex>
 #include <thread>
-
-
 
 namespace rmcl
 {
@@ -43,7 +35,6 @@ class MICPOnDnSensorCPU
 : public MICPSensorCPU
 {
 public:
-
   using Base = MICPSensorCPU;
 
   MICPOnDnSensorCPU(

--- a/rmcl_ros/include/rmcl_ros/micpl/MICPOnDnSensorCUDA.hpp
+++ b/rmcl_ros/include/rmcl_ros/micpl/MICPOnDnSensorCUDA.hpp
@@ -16,7 +16,6 @@
 
 #include <message_filters/subscriber.h>
 
-
 #include <rmagine/math/statistics.h>
 #include <rmagine/types/MemoryCuda.hpp>
 

--- a/rmcl_ros/include/rmcl_ros/micpl/MICPPinholeSensorCPU.hpp
+++ b/rmcl_ros/include/rmcl_ros/micpl/MICPPinholeSensorCPU.hpp
@@ -20,16 +20,10 @@
 
 #include <message_filters/subscriber.h>
 
-
 #include <rmagine/math/statistics.h>
 #include <rmagine/math/linalg.h>
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-
-// Correspondences
-#include <rmcl/registration/Correspondences.hpp>
-#include <rmcl/registration/RCCEmbree.hpp>
-
 
 #include <mutex>
 #include <thread>

--- a/rmcl_ros/include/rmcl_ros/micpl/MICPPinholeSensorCUDA.hpp
+++ b/rmcl_ros/include/rmcl_ros/micpl/MICPPinholeSensorCUDA.hpp
@@ -16,10 +16,8 @@
 
 #include <message_filters/subscriber.h>
 
-
 #include <rmagine/math/statistics.h>
 #include <rmagine/types/MemoryCuda.hpp>
-
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 

--- a/rmcl_ros/include/rmcl_ros/micpl/MICPSphericalSensorCPU.hpp
+++ b/rmcl_ros/include/rmcl_ros/micpl/MICPSphericalSensorCPU.hpp
@@ -20,16 +20,10 @@
 
 #include <message_filters/subscriber.h>
 
-
 #include <rmagine/math/statistics.h>
 #include <rmagine/math/linalg.h>
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-
-// Correspondences
-#include <rmcl/registration/Correspondences.hpp>
-#include <rmcl/registration/RCCEmbree.hpp>
-
 
 #include <mutex>
 #include <thread>

--- a/rmcl_ros/include/rmcl_ros/micpl/MICPSphericalSensorCUDA.hpp
+++ b/rmcl_ros/include/rmcl_ros/micpl/MICPSphericalSensorCUDA.hpp
@@ -16,10 +16,8 @@
 
 #include <message_filters/subscriber.h>
 
-
 #include <rmagine/math/statistics.h>
 #include <rmagine/types/MemoryCuda.hpp>
-
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 

--- a/rmcl_ros/package.xml
+++ b/rmcl_ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>rmcl_ros</name>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
     <description>The RMCL package. Software Tools for Mobile Robot Localization in 3D Meshes.</description>
 
     <maintainer email="amock@uos.de">Alexander Mock</maintainer>


### PR DESCRIPTION
After the OptiX headers were [open-sourced](https://github.com/NVIDIA/optix-dev), Rmagine integrated an automatic installation mode with [v2.3.1](https://github.com/uos/rmagine/pull/12). Embree or OptiX are installed automatically when they are missing. I quickly tested this, and it seems to work even when placing rmagine inside a ROS 2 workspace.

Futher, I removed some unnecessary includes.